### PR TITLE
add protocol for running powershell command (encoded as base64)

### DIFF
--- a/New-ToastNotification.ps1
+++ b/New-ToastNotification.ps1
@@ -751,7 +751,7 @@ function Write-CustomActionRegistry() {
     [CmdletBinding()]
     param (
         [Parameter(Position="0")]
-        [ValidateSet("ToastRunApplicationID","ToastRunPackageID","ToastRunUpdateID","ToastReboot")]
+        [ValidateSet("ToastRunApplicationID", "ToastRunPackageID", "ToastRunUpdateID", "ToastReboot", "ToastRunPSBase64")]
         [string]
         $ActionType,
         [Parameter(Position="1")]
@@ -820,6 +820,20 @@ function Write-CustomActionRegistry() {
                 Write-Log -Level Error -Message "Error message: $ErrorMessage"
             }
         }
+        ToastRunPSBase64 {
+            # Build out registry for custom action for running PowerShell command encoded as Base64 via the action button
+            try {
+                New-Item "HKCU:\Software\Classes\$($ActionType)\shell\open\command" -Force -ErrorAction SilentlyContinue | Out-Null
+                New-ItemProperty -LiteralPath "HKCU:\Software\Classes\$($ActionType)" -Name 'URL Protocol' -Value '' -PropertyType String -Force -ErrorAction SilentlyContinue | Out-Null
+                New-ItemProperty -LiteralPath "HKCU:\Software\Classes\$($ActionType)" -Name '(default)' -Value "URL:$($ActionType) Protocol" -PropertyType String -Force -ErrorAction SilentlyContinue | Out-Null
+                $RegCommandValue = $RegCommandPath + '\' + "$($ActionType).cmd `"%1`""
+                New-ItemProperty -LiteralPath "HKCU:\Software\Classes\$($ActionType)\shell\open\command" -Name '(default)' -Value $RegCommandValue -PropertyType String -Force -ErrorAction SilentlyContinue | Out-Null
+            } catch {
+                Write-Log -Level Error "Failed to create the $ActionType custom protocol in HKCU\Software\Classes. Action button might not work"
+                $ErrorMessage = $_.Exception.Message
+                Write-Log -Level Error -Message "Error message: $ErrorMessage"
+            }
+        }
     }
 }
 
@@ -831,7 +845,7 @@ function Write-CustomActionScript() {
     [CmdletBinding()]
     param (
         [Parameter(Position="0")]
-        [ValidateSet("ToastRunApplicationID","ToastRunPackageID","ToastRunUpdateID","ToastReboot")]
+        [ValidateSet("ToastRunApplicationID", "ToastRunPackageID", "ToastRunUpdateID", "ToastReboot", "ToastRunPSBase64")]
         [string] $Type,
         [Parameter(Position="1")]
         [String] $Path = $global:CustomScriptsPath
@@ -1097,6 +1111,41 @@ exit 0
             # Do not run another type; break
             Break
         }
+        # Create custom scripts to run PowerShell command encoded as Base64 directly from the action button
+        ToastRunPSBase64 {
+            try {
+                $CMDFileName = $Type + '.cmd'
+                $CMDFilePath = $Path + '\' + $CMDFileName
+                try {
+                    New-Item -Path $Path -Name $CMDFileName -Force -OutVariable PathInfo | Out-Null
+                } catch {
+                    $ErrorMessage = $_.Exception.Message
+                    Write-Log -Level Error -Message "Error message: $ErrorMessage"
+                }
+                try {
+                    $GetCustomScriptPath = $PathInfo.FullName
+                    [String]$Script = "
+set passedArg=%1
+:: remove part before : from passed string
+set base64=%passedArg:*:=%
+powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -WindowStyle Hidden -EncodedCommand %base64%"
+                    if (-NOT[string]::IsNullOrEmpty($Script)) {
+                        Out-File -FilePath $GetCustomScriptPath -InputObject $Script -Encoding ASCII -Force
+                    }
+                } catch {
+                    Write-Log -Level Error "Failed to create the custom .cmd script for $Type. Action button might not work"
+                    $ErrorMessage = $_.Exception.Message
+                    Write-Log -Level Error -Message "Error message: $ErrorMessage"
+                }
+
+            } catch {
+                Write-Log -Level Error "Failed to create the custom .cmd script for $Type. Action button might not work"
+                $ErrorMessage = $_.Exception.Message
+                Write-Log -Level Error -Message "Error message: $ErrorMessage"
+            }
+            # Do not run another type; break
+            Break
+        }
     }
 }
 
@@ -1105,7 +1154,7 @@ exit 0
 #region ######## GENERAL VARIABLES #########
 # Global variables
 # Setting global script version
-$global:ScriptVersion = "2.1.0"
+$global:ScriptVersion = "2.1.1"
 # Setting executing directory
 $global:ScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 # Setting global custom action script location
@@ -1346,7 +1395,11 @@ if(-NOT[string]::IsNullOrEmpty($Xml)) {
 #endregion ####### GENERAL VARIABLES #########
 
 #region ####### CHECKS #########
-
+if ($ActionButton1Content -match "^ToastRunPSBase64:\s*$") {
+    Write-Log -Level Error -Message "Error. Incomplete Value in the $Config file Action1 tag"
+    Write-Log -Level Error -Message "Error. You have to specify also the base64 encoded PowerShell command: like ToastRunPSBase64:bQBrAGQAaQByACAAQwA6AFwAdABlAG0AcABcAGIAYQBzAGUANgA0AA=="
+    Exit 1
+}
 if ($ActionButton1Content -match "^ToastRunApplicationID:\s*$") {
     Write-Log -Level Error -Message "Error. Incomplete Value in the $Config file Action1 tag"
     Write-Log -Level Error -Message "Error. You have to specify also the Application share link in format: ToastRunApplicationID:ScopeId_XXX/Application_YYY"
@@ -1626,10 +1679,12 @@ if ($CreateScriptsProtocolsEnabled -eq "True") {
                     Write-CustomActionRegistry -ActionType ToastRunApplicationID
                     Write-CustomActionRegistry -ActionType ToastRunPackageID
                     Write-CustomActionRegistry -ActionType ToastRunUpdateID
+                    Write-CustomActionRegistry -ActionType ToastRunPSBase64
                     Write-CustomActionScript -Type ToastReboot
                     Write-CustomActionScript -Type ToastRunApplicationID
                     Write-CustomActionScript -Type ToastRunPackageID
                     Write-CustomActionScript -Type ToastRunUpdateID
+                    Write-CustomActionScript -Type ToastRunPSBase64
                     New-ItemProperty -Path $global:RegistryPath -Name $RegistryName -Value $global:ScriptVersion -PropertyType "String" -Force | Out-Null
                 }
                 catch {


### PR DESCRIPTION
Added support for running **any PowerShell code through Action buttons**. Just use new protocol like this:

<Option Name="Action1" Value="ToastRunPSBase64:bQBrAGQAaQByACAAQwA6AFwAdABlAG0AcABcAGIAYQBzAGUANgA0AA==" />

Base64 encoded command can be generated like this:
$command = @'
mkdir C:\temp\abc
'@

# encode to base64
$bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
$encodedString = [Convert]::ToBase64String($bytes)
